### PR TITLE
Expose recently graded ranges as admin config values

### DIFF
--- a/zygrader/class_manager.py
+++ b/zygrader/class_manager.py
@@ -409,28 +409,6 @@ def download_roster(silent=False):
         window.run_layer(popup)
 
 
-def change_class():
-    """Change the current class.
-
-    This applies globally to all users of zygrader.
-    """
-    window = ui.get_window()
-    class_codes = SharedData.get_class_codes()
-
-    popup = ui.layers.ListLayer("Class Code", popup=True)
-    for code in class_codes:
-        popup.add_row_text(code)
-    window.run_layer(popup)
-    if popup.canceled:
-        return
-
-    code_index = popup.selected_index()
-    SharedData.set_current_class_code(class_codes[code_index])
-    popup = ui.layers.Popup("Changed Class",
-                            [f"Class changed to {class_codes[code_index]}"])
-    window.run_layer(popup)
-
-
 def lab_manager():
     window = ui.get_window()
 
@@ -460,5 +438,4 @@ def start():
     menu.add_row_text("Lab Manager", lab_manager)
     menu.add_row_text("Class Section Manager", class_section_manager)
     menu.add_row_text("Download Student Roster", download_roster)
-    menu.add_row_text("Change Class", change_class)
     window.register_layer(menu, "Class Manager")

--- a/zygrader/config/shared.py
+++ b/zygrader/config/shared.py
@@ -11,8 +11,14 @@ class SharedData:
     VERSION = LooseVersion("5.12.0")
 
     # Current class code (shared)
+    # Set from the admin > config menu for all users
     # Can be overridden on a user level
     CLASS_CODE = ""
+
+    # Defaults for recently locked ranges in minutes for grading and emails
+    # Can be configured from the admin > config menu
+    RECENT_LOCK_GRADES = 10
+    RECENT_LOCK_EMAILS = 2
 
     # The zygrader data exists in a hidden folder created by the --init-data-dir flag
     # This folder contains the shared configuration and the folders for each
@@ -60,6 +66,8 @@ class SharedData:
             print("No shared configuration exists")
             return False
 
+        cls.initialize_recently_locked()
+
         # Initialize current class
         current_class_code = cls.get_current_class_code()
 
@@ -69,6 +77,21 @@ class SharedData:
         cls.DIRECTORIES_INITIALIZED = True
 
         return True
+
+    @classmethod
+    def initialize_recently_locked(cls):
+        # If the settings do not exist save the defaults to config
+        # otherwise load from the config file
+        grades = cls.get_recently_locked("grades")
+        if not grades:
+            cls.set_recently_locked("grades", cls.RECENT_LOCK_GRADES)
+        else:
+            cls.RECENT_LOCK_GRADES = grades
+        emails = cls.get_recently_locked("emails")
+        if not emails:
+            cls.set_recently_locked("emails", cls.RECENT_LOCK_EMAILS)
+        else:
+            cls.RECENT_LOCK_EMAILS = emails
 
     @classmethod
     def initialize_class_data(cls, class_code):
@@ -169,6 +192,19 @@ class SharedData:
             return False
 
         return True
+
+    @classmethod
+    def get_recently_locked(cls, name: str):
+        name = f"{name}_recently_locked"
+        config = cls.get_shared_config()
+        return config.get(name, None)
+
+    @classmethod
+    def set_recently_locked(cls, name: str, duration: int):
+        name = f"{name}_recently_locked"
+        config = cls.get_shared_config()
+        config[name] = duration
+        cls.write_shared_config(config)
 
     @classmethod
     def get_class_codes(cls) -> list:

--- a/zygrader/email_manager.py
+++ b/zygrader/email_manager.py
@@ -1,6 +1,7 @@
 """Email: Manage locking of student emails from zygrader to prevent double-answering."""
 
 import curses
+from zygrader.config.shared import SharedData
 
 from zygrader import data, grader, ui, utils
 from zygrader.ui import colors
@@ -34,7 +35,7 @@ def lock_student_callback(student: data.Student):
 
     netid = utils.get_username()
     recently_locked, ts, netid = data.lock.was_recently_locked(
-        student, None, netid, range=2)
+        student, None, netid, range=SharedData.RECENT_LOCK_EMAILS)
 
     if recently_locked:
         name = data.netid_to_name(netid)

--- a/zygrader/grader.py
+++ b/zygrader/grader.py
@@ -324,7 +324,7 @@ def is_lab_available(use_locks, student, lab):
     # the TA to confirm that they haven't been graded already.
     current_netid = utils.get_username()
     recently_locked, ts, netid = data.lock.was_recently_locked(
-        student, lab, current_netid)
+        student, lab, current_netid, range=SharedData.RECENT_LOCK_GRADES)
     if recently_locked:
         name = data.netid_to_name(netid)
         msg = [

--- a/zygrader/ui/layers.py
+++ b/zygrader/ui/layers.py
@@ -392,6 +392,9 @@ class DatetimeSpinner(ComponentLayer):
     def set_quickpicks(self, quickpicks):
         self.component.set_quickpicks(quickpicks)
 
+    def set_format_str(self, format_str):
+        self.component.set_time_format(format_str)
+
     def event_handler(self, event: Event, event_manager: EventManager):
         if event.type in {Event.LEFT, Event.BTAB}:
             self.component.previous_field()


### PR DESCRIPTION
This adds a new Config menu to the admin menu for changing admin/global
options in zygrader. This makes it easier to adjust these values without
needing to make a new zygrader release. This does NOT change the default
values from what they were in previous releases.

The class code menu was also moved to the new Config menu similar to the
class code override in the user preferences.