### PR TITLE
Use fallback max scores

### DIFF
--- a/zygrader/class_manager.py
+++ b/zygrader/class_manager.py
@@ -114,6 +114,32 @@ def fill_lab_list(lab_list: ui.layers.ListLayer, labs: data.model.Lab):
         lab_list.add_row_text(str(lab), edit_labs_fn, lab, lab_list)
     lab_list.rebuild = True
 
+def set_max_score_text(lab: data.model.Lab, row: ui.layers.Row):
+    if "max_score" in lab.options:
+        row.set_row_text(f"Max Score: {lab.options['max_score']}")
+    else:
+        row.set_row_text("Max Score: None")
+
+def set_max_score(lab, row: ui.layers.Row):
+    window = ui.get_window()
+    labs = data.get_labs()
+
+    text_input = ui.layers.TextInputLayer("Max Score")
+    text_input.set_prompt(["Enter the max score for this lab"])
+    if "max_score" in lab.options:
+        text_input.set_text(str(lab.options["max_score"]))
+    window.run_layer(text_input)
+    if text_input.canceled:
+        return
+
+    try:
+        lab.options["max_score"] = int(text_input.get_text())
+        data.write_labs(labs)
+        set_max_score_text(lab, row)
+    except ValueError:
+        popup = ui.layers.Popup("Error")
+        popup.set_message(["Invalid input"])
+        window.run_layer(popup)
 
 def set_date_text(lab, row: ui.layers.Row):
     # Update the row text
@@ -210,6 +236,11 @@ def edit_lab_options(lab):
     row = popup.add_row_text("Due Date")
     row.set_callback_fn(set_due_date, lab, row)
     set_date_text(lab, row)
+
+    row = popup.add_row_text("Max Score")
+    row.set_callback_fn(set_max_score, lab, row)
+    set_max_score_text(lab, row)
+
     window.register_layer(popup)
 
 

--- a/zygrader/config/changelog.txt
+++ b/zygrader/config/changelog.txt
@@ -1,5 +1,11 @@
 # Try to keep lines shorter than 70 characters
 
+5.13.0
+* (Admin) add new option to set recently graded durations from
+  zygrader.
+* Fix crash when canceling the "Run Code" option
+* Fix crash in the grade puller with multiple-matched ids
+
 5.12.0
 * Added a check to prevent double-replies to student emails. If a
   student was locked within the last 2 minutes, a prompt will ask you

--- a/zygrader/config/shared.py
+++ b/zygrader/config/shared.py
@@ -8,7 +8,7 @@ from . import preferences
 
 class SharedData:
     # Zygrader version
-    VERSION = LooseVersion("5.12.0")
+    VERSION = LooseVersion("5.13.0")
 
     # Current class code (shared)
     # Set from the admin > config menu for all users

--- a/zygrader/config/versioning.py
+++ b/zygrader/config/versioning.py
@@ -165,6 +165,7 @@ def show_versioning_message(window: ui.Window):
         "5.10.0",
         "5.11.0",
         "5.12.0",
+        "5.13.0",
     ]
 
     updated = False

--- a/zygrader/data/model.py
+++ b/zygrader/data/model.py
@@ -316,7 +316,8 @@ class Submission(Iterable):
                     msg[-1] += f" [Compile Error]"
 
         msg.append("")
-        msg.append(f"Total Score: {response['score']}/{response['max_score']}")
+        percent = response["score"] / response["max_score"] * 100
+        msg.append(f"Total Score: {response['score']}/{response['max_score']} ({percent:0.2f}%)")
 
         self.msg = msg
 

--- a/zygrader/data/model.py
+++ b/zygrader/data/model.py
@@ -233,10 +233,19 @@ class Submission(Iterable):
         # Calculate score
         self.response["score"] = 0
         self.response["max_score"] = 0
+        incorrect_max = False
         for part in self.response["parts"]:
             if part["code"] != Zybooks.NO_SUBMISSION:
                 self.response["score"] += part["score"]
+                if part["max_score"] == 0:
+                    incorrect_max = True
                 self.response["max_score"] += part["max_score"]
+            else:
+                incorrect_max = True
+
+        # A submission part was missing so fall back on the max score saved in json
+        if incorrect_max:
+            self.response["max_score"] = self.lab.options["max_score"]
 
         # Create a list of test results.
         # There is a small chance that the test results may have changed
@@ -317,7 +326,9 @@ class Submission(Iterable):
 
         msg.append("")
         percent = response["score"] / response["max_score"] * 100
-        msg.append(f"Total Score: {response['score']}/{response['max_score']} ({percent:0.2f}%)")
+        msg.append(
+            f"Total Score: {response['score']}/{response['max_score']} ({percent:0.2f}%)"
+        )
 
         self.msg = msg
 

--- a/zygrader/data/model.py
+++ b/zygrader/data/model.py
@@ -458,6 +458,9 @@ class Submission(Iterable):
     def save_stderr(self, stderr):
         self.__stderr = stderr
 
+    def has_stderr(self) -> bool:
+        return self.__stderr != ""
+
     def view_stderr(self):
         utils.view_string(self.__stderr, "compile-error")
 
@@ -469,7 +472,7 @@ class Submission(Iterable):
         root_dir = self.files_directory
         if len(self.lab.parts) > 1:
             part = self.pick_part()
-            if part == ui.GO_BACK:
+            if part == None:
                 return False
 
             root_dir = os.path.join(

--- a/zygrader/grader.py
+++ b/zygrader/grader.py
@@ -421,7 +421,7 @@ def diff_parts_fn(window, submission):
     """Callback for text diffing parts of a submission"""
     error = submission.diff_parts()
     if error:
-        popup = ui.layer.Popup("Error", [error])
+        popup = ui.layers.Popup("Error", [error])
         window.run_layer(popup)
 
 

--- a/zygrader/grader.py
+++ b/zygrader/grader.py
@@ -172,7 +172,7 @@ def view_test_results(submission: model.Submission):
         row = popup.add_row_parent(part["name"])
         for test in part["tests"]:
             subrow = row.add_row_text(test["name"], view_test_io, test)
-            if test["type"] == "unit_test":
+            if not test["output"]:
                 subrow.set_disabled()
 
     window.run_layer(popup)

--- a/zygrader/grader.py
+++ b/zygrader/grader.py
@@ -207,9 +207,10 @@ def run_code_fn(window, submission):
     use_gdb = False
 
     if not submission.compile_and_run_code(use_gdb):
-        popup = ui.layers.OptionsPopup("Error", ["Could not compile code"])
-        popup.add_option("View Log", submission.view_stderr)
-        window.run_layer(popup)
+        if submission.has_stderr():
+            popup = ui.layers.OptionsPopup("Error", ["Could not compile code"])
+            popup.add_option("View Log", submission.view_stderr)
+            window.run_layer(popup)
 
 
 def pair_programming_submission_callback(lab, submission):

--- a/zygrader/zybooks.py
+++ b/zygrader/zybooks.py
@@ -283,7 +283,7 @@ class Zybooks:
             if bench["name"] == "unit_test":
                 test_input = ""
                 expected = ""
-                output = ""
+                output = result["test_output"]
                 type = "unit_test"
             else:
                 test_input = bench["options"]["input"]

--- a/zygrader/zybooks.py
+++ b/zygrader/zybooks.py
@@ -237,6 +237,17 @@ class Zybooks:
 
         return score
 
+    def __gen_fake_results(self, len: int) -> list:
+        """
+        When a submission fails to compile, there are test bench data, but no test
+        results data. This generates a fake list of results (no output with 0 scores).
+        """
+
+        results = []
+        for _ in range(len):
+            results.append({"score": 0, "output": ""})
+        return results
+
     def __get_test_results(self, submission: dict) -> dict:
         """
         Collects test results including the names and scores for each test case.
@@ -244,12 +255,15 @@ class Zybooks:
         """
 
         # if there is a compile error the test results are not populated
-        if submission["error"] or "compile_error" in submission["results"]:
+        if submission["error"]:
             return {"score": 0, "max_score": 0, "tests": []}
 
         results = submission["results"]
-        test_results = results["test_results"]
         test_bench = results["config"]["test_bench"]
+        if "test_results" in results:
+            test_results = results["test_results"]
+        else:
+            test_results = self.__gen_fake_results(len(test_bench))
 
         # find max test bench label name
         label_len = 0

--- a/zygrader/zybooks.py
+++ b/zygrader/zybooks.py
@@ -14,7 +14,7 @@ class SectionResponse:
         self.success = False
         self.id = ""
         self.name = ""
-
+        self.max_score = 0
 
 class Zybooks:
     NO_ERROR = 0
@@ -184,6 +184,10 @@ class Zybooks:
             response.success = True
             response.id = content["id"]
             response.name = content["caption"]
+
+            test_bench = content["payload"]["test_bench"]
+            for test in test_bench:
+                response.max_score += test["max_score"]
 
         return response
 


### PR DESCRIPTION
When a max (total) score for a submission part is not available due to a student not submitting a part, show a maximum score stored in the lab data. This means we now show more accurate scores when a student did not submit a portion of a lab.